### PR TITLE
Fix Vite build and restore preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mitchell Marfinetz Portfolio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { 
   Menu, 
   X, 

--- a/src/components/TechnicalProjectCard.tsx
+++ b/src/components/TechnicalProjectCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-// Removed Framer Motion imports
+import { motion, AnimatePresence } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
## Summary
- create `index.html` so Vite has an entry point
- restore `framer-motion` imports in `TechnicalProjectCard`
- remove unused `Badge` import in `Navigation`

## Testing
- `npm run build`
- `npm run preview` *(terminated immediately)*
- `bash test-minimal.sh`
- `bash test-full.sh`


------
https://chatgpt.com/codex/tasks/task_e_6886d223130083218b3b68cc090de4a9